### PR TITLE
fork-exec and std::process::Command (or vfork-exec) comparison

### DIFF
--- a/bin/foo/main.rs
+++ b/bin/foo/main.rs
@@ -1,3 +1,2 @@
 fn main() {
-    println!("Hello World!")
 }

--- a/run.sh
+++ b/run.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 count=500
+binary="target/release/foo"
+
 echo "Creating $count processes with parent memory of 5MB, 50MB, 100MB, 250MB, 500MB, 750MB, 1000MB"
 
 echo "fork-exec"
 for m in 5 50 100 250 500 750 1000;
 do
-    t="$(./target/release/process_create_compare -b target/release/foo -c $count -w 0 -m $m 2>&1 > /dev/null)"
+    t="$(./target/release/process_create_compare -b $binary -c $count -w 0 -m $m 2>&1 > /dev/null)"
     echo $t
 done
 
 echo "command"
 for m in 5 50 100 250 500 750 1000;
 do
-    t="$(./target/release/process_create_compare -b target/release/foo -c $count -w 3 -m $m 2>&1 > /dev/null)"
+    t="$(./target/release/process_create_compare -b $binary -c $count -w 3 -m $m 2>&1 > /dev/null)"
     echo $t
 done


### PR DESCRIPTION
This repo compares process creation latency between `fork-exec` and `std::process::Command` in Rust.
# Background
`std::process::Command` is really just a thin wrapper around `posix_spawn()` (See: [Command::spawn()](https://github.com/rust-lang/rust/blob/master/src/libstd/sys/unix/process/process_unix.rs#L30)), and `posix_spawn()` is essentially a `vfork()` followed by `execve()` (See: [posix_spawn(3)](http://man7.org/linux/man-pages/man3/posix_spawn.3.html)). So comparing fork-exec with `std::process::Command` is essentially comparing fork-exec with vfork-exec.
The major difference between `fork` and `vfork` is that `vfork` creates a new process without copying the page tables of the parent process (See [vfork(2)](http://man7.org/linux/man-pages/man2/vfork.2.html)).

# Experimental Setup
### fork-only vs e2e latency
I measure the latency of fork-exec and Command::spawn() in two different ways.
**On the `master` branch, latency is measured as:**
```rust
let t1 = precise_time_ns();
for _ in 0..count {
    fork_exec(binary);
}
let t2 = precise_time_ns();
```
similarly for `Command`:
```rust
let t1 = precise_time_ns();
for _ in 0..count {
    Command::new.spawn(binary);
}
let t2 = precise_time_ns();
```
(This snippet is simplified. See src/main.rs#L100-127 for actual code)

Note that `fork_exec()` returns to parent when `fork()` returns. So it doesn't capture the latency of `exec()`. Similarly, `Command::new.spawn()` returns when `posix_spawn()` returns which is when `vfork()` returns. Thus it doesn't capture the latency of `exec()` either.

Therefore, code on `master` branch measures only the latency of `fork()` and `vfork()`.

**On the `e2e` branch, latency is measured as:**
```rust
let t1 = precise_time_ns();
for _ in 0..count {
    fork_exec(binary);
    let status = wait::wait();                          
    if let Ok(wait::WaitStatus::Exited(_, _)) = status {
    }
}
let t2 = precise_time_ns();
```
similarly for `Command`:
```rust
let t1 = precise_time_ns();
for _ in 0..count {
    let mut c = Command::new.spawn(binary);
    c.wait().expect("failed to wait for child");
}
let t2 = precise_time_ns();
```
The parent waits for each child process to exit before creating the next child, so each measurement captures `fork()`, `exec()`, child process logic, child exit and `wait()` latency.

### Applications
I use 2 different applications for child processes:
1. bin/foo: does nothing and exits immediately
2. bin/prime: finds and prints out all prime numbers less than 100000.

### Machine
Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz
6 cores
16GB memory


# Results
raw numbers with graphs: https://docs.google.com/spreadsheets/d/1qeSZyPWBzHJOLbzd_htZOQAoSklUNUBQ_Blky-SmdMk/edit?usp=sharing

### fork-only latency
The following 2 graphs show average fork/vfork latency for parent memory size between 5MB and 1000MB. The first graph is for application foo and the second for prime.
![image](https://user-images.githubusercontent.com/9322921/71700415-2c4de900-2d92-11ea-856b-029747c2ed6e.png)
![image](https://user-images.githubusercontent.com/9322921/71700401-1b04dc80-2d92-11ea-9688-8c4f64c72c3c.png)

We can see that fork's latency increases roughly linearly w.r.t. parent's memory size, whereas vfork's latency stays constant regardless of parent's memory size. This is expected because the number of page table entries to copy grows linearly w.r.t. memory size.
vfork's latency is around 0.22ms.

### E2E latency
I only use application foo in this to minimize child process's latency.
![image](https://user-images.githubusercontent.com/9322921/71700608-ffe69c80-2d92-11ea-9a4f-e07f252ae3f2.png)

`Command::spawn` (vfork-exec) E2E latency stays around 1.5ms. `fork-exec`'s e2e latency increases roughly linearly w.r.t. parent's memory size.

Interestingly, `exec`'s latency also grows in the `fork-exec` case and stays constant in `Command`:
![image](https://user-images.githubusercontent.com/9322921/71700823-045f8500-2d94-11ea-9fe1-48c93e63ce51.png)
(This graph is the "foo e2e" graph minus the "foo" graph). 
A possible explanation is that because `exec` replaces child's heap, stack and data, the amount of necessary clean up work is proportional to the amount of inherited memory.

# Take-away
To target sub-ms VM creation, we should avoid `fork-exec` for latency purposes if the controller process grows beyond 5MB. `std::process::Command` seems to be a good option because it's really simple and lightweight. If I were to implement a thin wrapper around `vfork-exec`, I'd be essentially doing the same things.

# Run Experiments on Your Own
To run this experiment on your machine, build all binaries and run the `run.sh` script. Modify `run.sh` if you'd like to fit your purposes.